### PR TITLE
Minimum R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ URL: https://github.com/jamestsakalos/climenv
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr
-Depends: R (>= 3.6)
+Depends: R (>= 4.0)
 Imports:
     climaemet,
     dplyr,


### PR DESCRIPTION
It's not clear why the package requires 4.2 as the minimum version of R; none of the dependencies require greater than R4.0, and the package passes its tests on R4.0.

Setting a lower version may make the package accessible to users on older versions of R (e.g. where R must be installed by an organization's administrator).