### PR TITLE
Extract holdridge class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # climenv 1.0.0.9000 (development version)
 
-- Fix typos in documentation (thanks adamhsparks)
+- Return name of Holdridge zone in `bioclimate()` and `plot_h()`, resolving 
+  [#28](https://github.com/jamestsakalos/climenv/issues/28).
+- Fix typos in documentation (thanks adamhsparks).
 
 # climenv 1.0.0 #
 

--- a/R/bioclimate.R
+++ b/R/bioclimate.R
@@ -13,7 +13,8 @@
 #' - `abt`, mean annual biotemperature; mean annual temperature after
 #' replacing entries outside the range 0° to 30° with zeros;
 #' - `tap`, total annual precipitation (mm);
-#' - `per`, potential evapotranspiration ratio
+#' - `per`, potential evapotranspiration ratio;
+#' - `zone`, name of associated holdridge zone
 #'
 #' @author Martin R. Smith
 #' @references
@@ -25,21 +26,39 @@
 #' Holdridge L. R. (1959) Simple method for determining potential
 #' evapotranspiration from temperature data. *Science*, 130, 572.
 #' \doi{10.1126/science.130.3375.572}
+#' @examples
+#' # Step 1. Import the Italian Biome polygon data
+#' # Step 2. Run the download function
+#' # Step 3. Run the extract function
+#' #* See ce_download & ce_extract documentation
+#'
+#' # Steps 1, 2 & 3 can be skipped by loading the extracted data (it_data)
+#' data("it_data", package = "climenv")
+#'
+#' bioclimate(it_data$tavg_m[, 1:12], it_data$prec_m[, 1:12])
 #' @export
 bioclimate <- function(temp, prec) {
   if (!identical(dim(temp), dim(prec))) {
     stop("temp and prec should have the same dimensions")
   }
-  if (dim(temp)[2] != 12) {
+  if (dim(temp)[[2]] != 12) {
     stop("Columns of `temp` should correspond to the 12 months")
   }
   biotemp <- temp
   biotemp[temp < 0 | temp > 30] <- 0
-  abt <- unname(rowSums(biotemp) / 12)
+  abt <- rowSums(biotemp / 12)
   tap <- unname(rowSums(prec))
   ape <- abt * 58.93 # Constant given in Holdridge 1959
   per <- ape / tap
 
   # Return:
-  data.frame(abt = abt, tap = tap, per = per)
+  data.frame(abt = abt, tap = tap, per = per,
+             zone = .bioclimate_zone(per, tap))
+}
+
+.bioclimate_zone <- function(per, tap) {
+  hz <- Ternary::holdridge[, c("Precipitation", "PET")]
+  Ternary::holdridge[apply(apply(cbind(per, tap), 1, function(x) {
+    sqrt(rowSums((hz - x) ^ 2))
+  }), 2, which.min), "Holdridge_Zones"]
 }

--- a/R/bioclimate.R
+++ b/R/bioclimate.R
@@ -41,5 +41,5 @@ bioclimate <- function(temp, prec) {
   per <- ape / tap
 
   # Return:
-  cbind(abt = abt, tap = tap, per = per)
+  data.frame(abt = abt, tap = tap, per = per)
 }

--- a/R/plot_h.R
+++ b/R/plot_h.R
@@ -10,8 +10,10 @@
 #' `HoldridgePoints()`.
 #'
 #' @returns
-#' Returns a base R family of plot. This function uses the \pkg{Ternary}
-#' package to create a Holdridge simplex plot.
+#' `plot_h()` is principally called for its side-effects: it creates a
+#' Holdridge simplex plot using the base R graphics functions, _via_ the
+#' \pkg{Ternary} package.  It invisibly returns the results of a call to
+#' `bioclimate()`, which reports the Holdridge data associated with each point.
 #'
 #' @author James L. Tsakalos and Martin R. Smith
 #' @seealso Download climate data: [`ce_download()`]
@@ -70,6 +72,8 @@ plot_h <- function(
                            col = col, cex = 2, pch = pch,
                            lwd = 2, ...)
 
+  # Return:
+  invisible(hold)
 }
 
 .validate_geo_id <- function(geo_id, data) {

--- a/man/bioclimate.Rd
+++ b/man/bioclimate.Rd
@@ -20,12 +20,24 @@ correspond to:
 \item \code{abt}, mean annual biotemperature; mean annual temperature after
 replacing entries outside the range 0° to 30° with zeros;
 \item \code{tap}, total annual precipitation (mm);
-\item \code{per}, potential evapotranspiration ratio
+\item \code{per}, potential evapotranspiration ratio;
+\item \code{zone}, name of associated holdridge zone
 }
 }
 \description{
 Calculates the values of bioclimatic indices from monthly temperature and
 precipitation measurements, following Szelepcsényi et al. 2014.
+}
+\examples{
+# Step 1. Import the Italian Biome polygon data
+# Step 2. Run the download function
+# Step 3. Run the extract function
+#* See ce_download & ce_extract documentation
+
+# Steps 1, 2 & 3 can be skipped by loading the extracted data (it_data)
+data("it_data", package = "climenv")
+
+bioclimate(it_data$tavg_m[, 1:12], it_data$prec_m[, 1:12])
 }
 \references{
 Szelepcsényi Z, Breuer H, Sümegi P (2014)

--- a/man/plot_h.Rd
+++ b/man/plot_h.Rd
@@ -18,8 +18,10 @@ data sets. Structured by \code{ce_extract()}.}
 \code{HoldridgePoints()}.}
 }
 \value{
-Returns a base R family of plot. This function uses the \pkg{Ternary}
-package to create a Holdridge simplex plot.
+\code{plot_h()} is principally called for its side-effects: it creates a
+Holdridge simplex plot using the base R graphics functions, \emph{via} the
+\pkg{Ternary} package.  It invisibly returns the results of a call to
+\code{bioclimate()}, which reports the Holdridge data associated with each point.
 }
 \description{
 Creates a graph using the climate and elevation data which has

--- a/tests/testthat/test-bioclimate.R
+++ b/tests/testthat/test-bioclimate.R
@@ -7,8 +7,17 @@ test_that("bioclimate() fails gracefully", {
 
 test_that("bioclimate() returns expected values", {
   data(it_data)
+  if (interactive()) {
+    plot_h(it_data, c("MED", "NEM"), col = hcl.colors(2))
+  }
   expect_equal(tolerance = 0.01,
     bioclimate(it_data$tavg_m["MED", 1:12], it_data$prec_m["MED", 1:12]),
-    data.frame(abt = 15.6, tap = 625, per = 1.47)
+    data.frame(abt = 15.6, tap = 625, per = 1.47,
+               zone = "Tropical very dry forest", row.names = "MED")
+  )
+  expect_equal(
+    bioclimate(it_data$tavg_m[, 1:12], it_data$prec_m[, 1:12])[
+      c("NEM", "MED"), "zone"],
+    c("Subtropical dry forest", "Tropical very dry forest")
   )
 })

--- a/tests/testthat/test-bioclimate.R
+++ b/tests/testthat/test-bioclimate.R
@@ -4,3 +4,11 @@ test_that("bioclimate() fails gracefully", {
   expect_error(bioclimate(matrix(1:24, 12), matrix(1:12)),
                "should have the same dimensions")
 })
+
+test_that("bioclimate() returns expected values", {
+  data(it_data)
+  expect_equal(tolerance = 0.01,
+    bioclimate(it_data$tavg_m["MED", 1:12], it_data$prec_m["MED", 1:12]),
+    data.frame(abt = 15.6, tap = 625, per = 1.47)
+  )
+})


### PR DESCRIPTION
Resolves #28 .

Two principal changes:
- `bioclimate()` returns a column corresponding to the Holdridge zone associated with each point, looked up from the definitions in `Ternary`;
- `plot_h()` invisibly returns this bioclimate data (previously the outcome of the call to `plot.xy()` was returned).

Note that I also updated the returned value of `bioclimate()` from a numeric matrix to a  `data.frame`, matching the existing documentation.