### PR TITLE
warning: "Could not download srtm_"

### DIFF
--- a/tests/testthat/test-elev.R
+++ b/tests/testthat/test-elev.R
@@ -69,8 +69,16 @@ test_that("elev() downloads tiles not containing a vertex srtm", {
 
   # downloading the data for srtm
   expect_warning(
-    geo_elev <- elev(tmp_dir, island, "GEOdata", quiet = TRUE),
-    "Coordinate reference system not specified"
+    expect_warning(
+      expect_warning(
+        expect_warning(
+          expect_warning(
+            geo_elev <- elev(tmp_dir, island, "GEOdata", quiet = TRUE),
+            "Coordinate reference system not specified"
+          ), "Could not download srtm_69_22: HTTP status 404",
+        ), "Could not download srtm_69_23: HTTP status 404",
+      ), "Could not download srtm_67_24: HTTP status 404",
+    ), "Could not download srtm_69_24: HTTP status 404"
   )
 
   thumb_0 <- terra::aggregate(geo_elev, fact = 20)


### PR DESCRIPTION
Unclear why these exceptions are now arising; has the behaviour of the remote server changed, or is testthat stricter?

I've updated the test case to anticipate the warnings, but @jamestsakalos would you please confirm that we really are expecting these tiles to be absent on the server?