### PR TITLE
tmean→tave

### DIFF
--- a/R/chelsa.R
+++ b/R/chelsa.R
@@ -11,13 +11,13 @@
 #' `download.file()`.
 #'
 #' @returns
-#' Returns four subfolders named prec, tmax, tmin and tmean. Each folder
+#' Returns four subfolders named prec, tmax, tmin and tave. Each folder
 #' contains 12 GeoTiff (.tif) files, one for each month of the year for the time
 #' period 1981&ndash;2010. Each of the files are downloaded at a spatial
 #' resolution of 30 arc seconds (&#126;1 km  sq.). The precipitation folder
 #' contains average monthly precipitation (mm). The tmax folder contains maximum
 #' monthly temperature. The tmin folder contains minimum monthly temperature.
-#' The tmean folder contains the average monthly temperature. The unit of
+#' The tave folder contains the average monthly temperature. The unit of
 #' measure for temperature is in &deg;C.
 #'
 #' @author James L. Tsakalos and Martin R. Smith

--- a/R/data_it_data.R
+++ b/R/data_it_data.R
@@ -6,10 +6,10 @@
 #' @format{ An object of class \code{list} of length 12.}
 #' @details Returns a 11 data frames and one 'Readme' note. Eight feature
 #' climate data (i.e., one each for the mean and standard deviation of tmax,
-#' tmean, tmin and prec). Within each data frame the columns represent a month
+#' tave, tmin and prec). Within each data frame the columns represent a month
 #' (Jan–Dec), each row represents a feature of the \code{location} \code{sp},
 #' \code{sf} polygon or point object. Values returned are either degrees
-#' Celsius for (tmax, tmean, tmin) or mm (prec). One data frame features
+#' Celsius for (tmax, tave, tmin) or mm (prec). One data frame features
 #' elevation data. Within this data frame, one column shows the mean and the
 #' second the standard deviation. One data frame contains the central latitude
 #' of each feature. One, called "abmt" features the absolute minimum

--- a/R/data_it_data_extended.R
+++ b/R/data_it_data_extended.R
@@ -6,10 +6,10 @@
 #' @format{ An object of class \code{list} of length 12.}
 #' @details Returns a 11 data frames and one 'Readme' note. Eight feature
 #' climate data (i.e., one each for the mean and standard deviation of tmax,
-#' tmean, tmin and prec). Within each data frame the columns represent a month
+#' tave, tmin and prec). Within each data frame the columns represent a month
 #' (Jan–Dec), each row represents a feature of the \code{location} \code{sp},
 #' \code{sf} polygon or point object. Values returned are either degrees
-#' Celsius for (tmax, tmean, tmin) or mm (prec). One data frame features
+#' Celsius for (tmax, tave, tmin) or mm (prec). One data frame features
 #' elevation data. Within this data frame, one column shows the mean and the
 #' second the standard deviation. One data frame contains the central latitude
 #' of each feature. One, called "abmt" features the absolute minimum

--- a/R/worldclim.R
+++ b/R/worldclim.R
@@ -65,13 +65,13 @@
 #'
 #' @return
 #' `worldclim()` is called for its side effects and returns `NULL`.
-#' Creates four subfolders named prec, tmax, tmin and tmean. Each folder
+#' Creates four subfolders named prec, tmax, tmin and tave. Each folder
 #' contains 12 GeoTiff (.tif) files, one for each month of the year for the time
 #' period 1970&ndash;2000. Each of the files are downloaded at a spatial
 #' resolution of 0.5 minutes of a degree. The precipitation folder contains
 #' average monthly precipitation (mm). The tmax folder contains maximum monthly
 #' temperature. The tmin folder contains minimum monthly
-#' temperature. The tmean folder contains the average monthly temperature.
+#' temperature. The tave folder contains the average monthly temperature.
 #' Temperature values are reported in &deg;C.
 #'
 #' @author James L. Tsakalos and Martin R. Smith

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -94,7 +94,6 @@ Szelepcsényi
 tavg
 th
 tmax
-tmean
 tmin
 TS
 VEB

--- a/man-roxygen/output_var_param.R
+++ b/man-roxygen/output_var_param.R
@@ -1,3 +1,3 @@
 #' @param var Character. If supplied will download a subset of the climate data.
-#' Must be one of `"all"` (default), `"prec"`, `"tmax"`, `"tmin"` or `"tmean"`
+#' Must be one of `"all"` (default), `"prec"`, `"tmax"`, `"tmin"` or `"tave"`
 #' to download the corresponding climate data.

--- a/man/ce_download.Rd
+++ b/man/ce_download.Rd
@@ -24,7 +24,7 @@ climate data source.}
 elevation data source.}
 
 \item{var}{Character. If supplied will download a subset of the climate data.
-Must be one of \code{"all"} (default), \code{"prec"}, \code{"tmax"}, \code{"tmin"} or \code{"tmean"}
+Must be one of \code{"all"} (default), \code{"prec"}, \code{"tmax"}, \code{"tmin"} or \code{"tave"}
 to download the corresponding climate data.}
 
 \item{location}{A \code{"sp"}, \code{"sf"} polygon or point object. See

--- a/man/ce_extract.Rd
+++ b/man/ce_extract.Rd
@@ -32,7 +32,7 @@ warning issued.}
 climate data source.}
 
 \item{var}{Character. If supplied will download a subset of the climate data.
-Must be one of \code{"all"} (default), \code{"prec"}, \code{"tmax"}, \code{"tmin"} or \code{"tmean"}
+Must be one of \code{"all"} (default), \code{"prec"}, \code{"tmax"}, \code{"tmin"} or \code{"tave"}
 to download the corresponding climate data.}
 }
 \value{

--- a/man/chelsa.Rd
+++ b/man/chelsa.Rd
@@ -11,20 +11,20 @@ chelsa(output_dir = NULL, var = "all", quiet = FALSE, ...)
 the data will be stored.}
 
 \item{var}{Character. If supplied will download a subset of the climate data.
-Must be one of \code{"all"} (default), \code{"prec"}, \code{"tmax"}, \code{"tmin"} or \code{"tmean"}
+Must be one of \code{"all"} (default), \code{"prec"}, \code{"tmax"}, \code{"tmin"} or \code{"tave"}
 to download the corresponding climate data.}
 
 \item{quiet, \dots}{Arguments to control a download from the Internet
 \code{download.file()}.}
 }
 \value{
-Returns four subfolders named prec, tmax, tmin and tmean. Each folder
+Returns four subfolders named prec, tmax, tmin and tave. Each folder
 contains 12 GeoTiff (.tif) files, one for each month of the year for the time
 period 1981–2010. Each of the files are downloaded at a spatial
 resolution of 30 arc seconds (~1 km  sq.). The precipitation folder
 contains average monthly precipitation (mm). The tmax folder contains maximum
 monthly temperature. The tmin folder contains minimum monthly temperature.
-The tmean folder contains the average monthly temperature. The unit of
+The tave folder contains the average monthly temperature. The unit of
 measure for temperature is in °C.
 }
 \description{

--- a/man/it_data.Rd
+++ b/man/it_data.Rd
@@ -16,10 +16,10 @@ The package contains climatic data extracted for the Biomes of Italy.
 \details{
 Returns a 11 data frames and one 'Readme' note. Eight feature
 climate data (i.e., one each for the mean and standard deviation of tmax,
-tmean, tmin and prec). Within each data frame the columns represent a month
+tave, tmin and prec). Within each data frame the columns represent a month
 (Jan–Dec), each row represents a feature of the \code{location} \code{sp},
 \code{sf} polygon or point object. Values returned are either degrees
-Celsius for (tmax, tmean, tmin) or mm (prec). One data frame features
+Celsius for (tmax, tave, tmin) or mm (prec). One data frame features
 elevation data. Within this data frame, one column shows the mean and the
 second the standard deviation. One data frame contains the central latitude
 of each feature. One, called "abmt" features the absolute minimum

--- a/man/it_data_extended.Rd
+++ b/man/it_data_extended.Rd
@@ -16,10 +16,10 @@ The package contains climatic data extracted for the Biomes of Italy.
 \details{
 Returns a 11 data frames and one 'Readme' note. Eight feature
 climate data (i.e., one each for the mean and standard deviation of tmax,
-tmean, tmin and prec). Within each data frame the columns represent a month
+tave, tmin and prec). Within each data frame the columns represent a month
 (Jan–Dec), each row represents a feature of the \code{location} \code{sp},
 \code{sf} polygon or point object. Values returned are either degrees
-Celsius for (tmax, tmean, tmin) or mm (prec). One data frame features
+Celsius for (tmax, tave, tmin) or mm (prec). One data frame features
 elevation data. Within this data frame, one column shows the mean and the
 second the standard deviation. One data frame contains the central latitude
 of each feature. One, called "abmt" features the absolute minimum

--- a/man/worldclim.Rd
+++ b/man/worldclim.Rd
@@ -19,13 +19,13 @@ objects.}
 }
 \value{
 \code{worldclim()} is called for its side effects and returns \code{NULL}.
-Creates four subfolders named prec, tmax, tmin and tmean. Each folder
+Creates four subfolders named prec, tmax, tmin and tave. Each folder
 contains 12 GeoTiff (.tif) files, one for each month of the year for the time
 period 1970–2000. Each of the files are downloaded at a spatial
 resolution of 0.5 minutes of a degree. The precipitation folder contains
 average monthly precipitation (mm). The tmax folder contains maximum monthly
 temperature. The tmin folder contains minimum monthly
-temperature. The tmean folder contains the average monthly temperature.
+temperature. The tave folder contains the average monthly temperature.
 Temperature values are reported in °C.
 }
 \description{

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -270,7 +270,7 @@ test_that("ce_extract() works", {
 
   # .clim_extract
   expect_error(.clim_extract(
-    which_clim = "tmean",
+    which_clim = "tave",
     location = pol_pt,
     location_type = "SpatialPointsDataFrame",
     location_g = "grp",

--- a/vignettes/climenv.Rmd
+++ b/vignettes/climenv.Rmd
@@ -133,7 +133,7 @@ for (i in seq_along(temp2)) {
   writeRaster(r, paste0(temp_path, "/tmin/", temp2[i]))
 }
 
-# tmean
+# tave
 x <- c(43, 38, 33, 29, 25, 19.8, 17.01, 21, 25, 30, 37, 44) -
   c(c(43, 38, 33, 29, 25, 19.8, 17.01, 21, 25, 30, 37, 44) / 2) / 2
 temp2 <- paste0("tavg_", sprintf("%02d", 1:12), ".tif")


### PR DESCRIPTION
Substituting `tave` for `tmean` (the more precise term) throughout the codebase threw errors in the test suite, so I have proposed using `tave` exclusively – which presumably reflects usage at CHELSA?

If that's correct, then this PR will close #32 .